### PR TITLE
feat(esm): convert loader to generate esm module statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,6 @@ module.exports = function(source) {
             return cb(err);
         }
 
-        cb(null, 'module.exports = ' + JSON.stringify(bld));
+        cb(null, 'export default ' + JSON.stringify(bld));
     });
 };


### PR DESCRIPTION
This converts `module.exports =` to `export default` which will allow webpack to scope hoist and better tree shake libs like threeJS


Before analysis: 
![image](https://user-images.githubusercontent.com/3408176/38283393-a9374184-376a-11e8-8067-fe9a05907152.png)

After change analysis: 
![image](https://user-images.githubusercontent.com/3408176/38283420-caab47e8-376a-11e8-8586-f0efc3079d5a.png)

Note that many more modules are concatenated together because they are using esm syntax. This enables faster runtimes and smaller bundles! 
