### PR TITLE
Removing tailing `;` and explicit local folder `./` 

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var path = require('path');
 
 function parse(loader, source, context, cb) {
     var imports = [];
-    var importPattern = /#include "([.\/\w_-]+)";/gi;
+    var importPattern = /#include "([.\/\w_-]+)"/gi;
     var match = importPattern.exec(source);
 
     while (match != null) {

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function processImports(loader, source, context, imports, cb) {
 
     var imp = imports.pop();
 
-    loader.resolve(context, imp.key, function(err, resolved) {
+    loader.resolve(context, './' + imp.key, function(err, resolved) {
         if (err) {
             return cb(err);
         }


### PR DESCRIPTION
C style `#include` precompile macro don't require tailing `;` also there is no requirement to call local folder `./` explicitly.
By making it a requirement on the RegEx forks the behaviour of a well know pattern

As context I'm making [a multilanguage shader library call lygia](https://github.com/patriciogonzalezvivo/lygia) and I wish to use your webpack module to load it, but doesn't work as is. 