### PR TITLE
Allow webpack's loader to resolve imports directly

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function processImports(loader, source, context, imports, cb) {
 
     var imp = imports.pop();
 
-    loader.resolve(context, './' + imp.key, function(err, resolved) {
+    loader.resolve(context, imp.key, function(err, resolved) {
         if (err) {
             return cb(err);
         }


### PR DESCRIPTION
Currently the resolve line prepends a './' to the import key, meaning that if I try to reference code that lives in an external package, it will fail to resolve. Removing the restriction of imports being relative to the current file allows me to specify a GLSL library in one package, and reference it in another, greatly increasing the utility of this loader.